### PR TITLE
Add command to periodically clear the database

### DIFF
--- a/.ebextensions/03_clear_db.config
+++ b/.ebextensions/03_clear_db.config
@@ -1,0 +1,21 @@
+files:
+    "/etc/cron.d/clear_database":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            0 0 * * 0 root /usr/local/bin/clear_db.sh
+
+    "/usr/local/bin/clear_db.sh":
+        mode: "000755"
+        owner: root
+        group: root
+        content: |
+            #!/bin/bash
+            sudo docker exec \
+            $(cat `sudo /opt/elasticbeanstalk/bin/get-config container -k app_deploy_file`) \
+            /bin/bash -c "python manage.py cleardb && python manage.py populatedb"
+
+commands:
+    remove_old_cron:
+        command: "rm -f /etc/cron.d/*.bak"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY wsgi/ /app/saleor/wsgi/
 RUN mv /app/templates/base.html /app/templates/base_original.html
 RUN mv /app/templates/dashboard/base.html /app/templates/dashboard/base_original.html
 COPY templates/ /app/templates/
+COPY cleardb.py /app/saleor/core/management/commands/
 
 EXPOSE 8000
 ENV PORT 8000

--- a/cleardb.py
+++ b/cleardb.py
@@ -1,0 +1,52 @@
+"""
+This script is used to periodically clear the database in the Saleor demo app.
+The script is copied to the proper location which makes it accessible for
+`python manage.py` command.
+"""
+
+from __future__ import unicode_literals
+
+from django.core.management.base import BaseCommand
+
+from saleor.cart.models import Cart
+from saleor.discount.models import Sale, Voucher
+from saleor.order.models import Order, Payment
+from saleor.product.models import Product
+from saleor.shipping.models import ShippingMethod
+from saleor.userprofile.models import User
+
+
+class Command(BaseCommand):
+    help = 'Clear database preserving staff accounts and configuration'
+
+    def handle(self, *args, **kwargs):
+        Cart.objects.all().delete()
+        self.stdout.write('Removed carts')
+
+        Payment.objects.all().delete()
+        self.stdout.write('Removed payments')
+
+        Order.objects.all().delete()
+        self.stdout.write('Removed orders')
+
+        Product.objects.all().delete()
+        self.stdout.write('Removed products')
+
+        Sale.objects.all().delete()
+        self.stdout.write('Removed sales')
+
+        ShippingMethod.objects.all().delete()
+        self.stdout.write('Removed shipping methods')
+
+        Voucher.objects.all().delete()
+        self.stdout.write('Removed vouchers')
+
+        # Delete all users except for staff members.
+        staff = User.objects.filter(is_staff=True)
+        User.objects.exclude(pk__in=staff).delete()
+        self.stdout.write('Removed customers')
+
+        # Remove addresses of staff members.
+        for user in staff:
+            user.addresses.all().delete()
+        self.stdout.write('Removed staff addresses')


### PR DESCRIPTION
This PR adds a command that clears the database, preserving all the configuration and staff accounts. The command should be accessible to `python manage.py`.

TODO:
- [ ] Configure Cron task that will periodically run: `python manage.py cleardb && python manage.py populatedb`. Running it once a week should be fine.