### PR TITLE
Block account password form and stop at the first match

### DIFF
--- a/wsgi/readonly_dashboard.py
+++ b/wsgi/readonly_dashboard.py
@@ -1,14 +1,28 @@
 import random
+import re
+
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_bytes
+
+BLOCKED_URL = [
+    re.compile(r'^/dashboard'),
+    re.compile(r'^/([\w-]+/)?account/$')]
+
+
+def _is_url_blocked(url):
+    for pattern in BLOCKED_URL:
+        yield pattern.match(url)
+
+
+def _is_request_blocked(environ):
+    is_post = environ['REQUEST_METHOD'] == 'POST'
+    request_url = environ['PATH_INFO']
+    return is_post and any(_is_url_blocked(request_url))
 
 
 def readonly_dashboard(application):
     def wrapper(environ, start_response):
-        blocked_urls = ['/dashboard', '/profile']
-        is_blocked = any(
-            [environ.get('PATH_INFO').startswith(url) for url in blocked_urls])
-        if is_blocked and environ['REQUEST_METHOD'] == 'POST':
+        if _is_request_blocked(environ):
             start_response('200 OK', [('Content-Type', 'text/html')])
             image = random.randrange(1, 6)
             ctx = {


### PR DESCRIPTION
This pull request fixes #25. The aim of this change is to block users from changing their password without blocking the account address form.

This change also refactor the logic to only check if the url match only if the HTTP method is `POST` and stop checking as soon as a match occurs.